### PR TITLE
ログイン画面に飛ぶボタンの削除

### DIFF
--- a/src/screens/HomeScreen/sections/UserProfileSection/UserProfileSection.tsx
+++ b/src/screens/HomeScreen/sections/UserProfileSection/UserProfileSection.tsx
@@ -1,10 +1,6 @@
-import { useNavigate } from "react-router-dom";
-import { Button } from "../../../../components/ui/button";
-import { ArrowRightIcon } from "lucide-react";
 import { UserName } from "../../../../components/UserName";
 
 export const UserProfileSection = (): JSX.Element => {
-  const navigate = useNavigate();
 
   return (
     <header className="w-full bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-md rounded-b-2xl">
@@ -17,14 +13,6 @@ export const UserProfileSection = (): JSX.Element => {
             </div>
             <h1 className="font-bold text-lg">除雪作業日報</h1>
           </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="w-10 h-10 rounded-lg bg-white text-blue-600 text-3xl font-bold shadow-md hover:bg-blue-100 hover:scale-105 transition-all"
-            onClick={() => navigate("/loginscreen")}
-          >
-            <ArrowRightIcon className="w-5 h-5 text-blue text-3xl" />
-          </Button>
         </div>
 
         {/* Profile info */}


### PR DESCRIPTION
ホーム画面上部に表示されていた、ログイン画面に遷移する矢印ボタンを削除しました。詳細は #20 をご確認ください。

close #20 