### PR TITLE
タコメーター撮影処理の実装

### DIFF
--- a/src/screens/ReportInputScreen/ReportInputScreen.tsx
+++ b/src/screens/ReportInputScreen/ReportInputScreen.tsx
@@ -22,10 +22,8 @@ export const ReportInputScreen = (): JSX.Element => {
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [tachometerValue, setTachometerValue] = useState("");
-  const [tachometerPhotos, setTachometerPhotos] = useState<TachometerPhoto[]>(
-    []
-  );
-
+  const [tachometerPhotos, setTachometerPhotos] = useState<TachometerPhoto[]>([],);
+  const [tachometerMemos, setTachometerMemos] = useState<string[]>([]);
   const { name, userId } = getCurrentUser();
 
   const isoToDate = (iso?: string) => {
@@ -68,8 +66,8 @@ export const ReportInputScreen = (): JSX.Element => {
     field_workDate: isoToDate(p?.field_workDate),
     field_workPlaceId: asArr(p?.field_workPlaceId),
     field_weather: Array.isArray(p?.field_weather)
-      ? p.field_weather[0] ?? ""
-      : p?.field_weather ?? "",
+      ? (p.field_weather[0] ?? "")
+      : (p?.field_weather ?? ""),
     field_workerName: p?.field_workerName ?? name,
     field_assistantId: asArr(p?.field_assistantId) ?? userId,
     field_assistantName: p?.field_assistantName ?? "",
@@ -81,7 +79,7 @@ export const ReportInputScreen = (): JSX.Element => {
     field_removalVolume:
       typeof p?.field_removalVolume === "number"
         ? String(p?.field_removalVolume)
-        : p?.field_removalVolume ?? "",
+        : (p?.field_removalVolume ?? ""),
   });
 
   const {
@@ -98,7 +96,7 @@ export const ReportInputScreen = (): JSX.Element => {
   });
 
   const [selectedLocationId, setSelectedLocationId] = useState<number | null>(
-    null
+    null,
   );
   const [selectedClassId, setSelectedClassId] = useState<string[] | null>(null);
 
@@ -182,18 +180,11 @@ export const ReportInputScreen = (): JSX.Element => {
     try {
       const record = toJdbRecord(values);
       await postReport(record);
-
-      // タコメーター項目は現時点ではUI保持のみ
-      console.log("tachometerValue:", tachometerValue);
-      console.log(
-        "tachometerPhotos:",
-        tachometerPhotos.map((photo) => photo.file)
-      );
-
       setShowConfirmation(false);
       reset();
       setTachometerValue("");
       setTachometerPhotos([]);
+      setTachometerMemos([]);
       setSelectedLocationId(null);
       setSelectedClassId(null);
     } catch (error) {
@@ -313,8 +304,9 @@ export const ReportInputScreen = (): JSX.Element => {
               onTachometerChange={setTachometerValue}
               photos={tachometerPhotos}
               onPhotosChange={setTachometerPhotos}
+              memos={tachometerMemos}
+              onMemosChange={setTachometerMemos}
             />
-
             <WorkRecordSection
               register={register}
               errors={errors}

--- a/src/screens/ReportInputScreen/ReportInputScreen.tsx
+++ b/src/screens/ReportInputScreen/ReportInputScreen.tsx
@@ -9,6 +9,10 @@ import { WorkDurationSection } from "../../components/reportUi/WorkDurationSecti
 import { WorkPlaceSection } from "../../components/reportUi/WorkPlaceSection/WorkPlaceSection";
 import { WorkRecordSection } from "../../components/reportUi/WorkRecordSection/WorkRecordSection";
 import { WorkerVehicleSection } from "../../components/reportUi/WorkerVehicleSection/WorkerVehicleSection";
+import {
+  TachometerSection,
+  type TachometerPhoto,
+} from "./sections/TachometerSection";
 import { UserName } from "../../components/UserName";
 import type { ReportPostData } from "../../types/reportForm";
 import { postReport } from "../../hook/postReport";
@@ -17,14 +21,15 @@ import { getCurrentUser } from "../../hook/getCurrentUser";
 export const ReportInputScreen = (): JSX.Element => {
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [tachometerValue, setTachometerValue] = useState("");
+  const [tachometerPhotos, setTachometerPhotos] = useState<TachometerPhoto[]>(
+    []
+  );
 
-  // 現在のログイン中のユーザーの取得
-  const {name, userId} = getCurrentUser();
+  const { name, userId } = getCurrentUser();
 
-  // ---------- helpers ----------
   const isoToDate = (iso?: string) => {
     if (!iso) {
-      // 日本時間で今日の日付を取得
       return new Date()
         .toLocaleDateString("ja-JP", {
           timeZone: "Asia/Tokyo",
@@ -32,8 +37,9 @@ export const ReportInputScreen = (): JSX.Element => {
           month: "2-digit",
           day: "2-digit",
         })
-        .replace(/\//g, "-"); // 2025/10/30 → 2025-10-30
+        .replace(/\//g, "-");
     }
+
     const m = iso.match(/^(\d{4}-\d{2}-\d{2})/);
     return m ? m[1] : iso;
   };
@@ -94,35 +100,15 @@ export const ReportInputScreen = (): JSX.Element => {
   const [selectedLocationId, setSelectedLocationId] = useState<number | null>(
     null
   );
-
   const [selectedClassId, setSelectedClassId] = useState<string[] | null>(null);
-
 
   const values = watch();
 
-  // デバッグログを追加
-  // console.log("現在のフォーム値:", values);
-  // console.log("field_workerId:", values.field_workerId);
-  // console.log("field_carId:", values.field_carId);
-  // console.log("field_assistantId:", values.field_assistantId);
-
-  // ---------- converter helpers ----------
   const toJdbRef = (val?: string | number | null): string[] => {
     if (val === undefined || val === null || val === "") return [];
     const s = String(val);
     return ["", s, "", s];
   };
-
-  // const first = (arr?: unknown) => {
-  //   const result = Array.isArray(arr)
-  //     ? (arr[0] as string | undefined)
-  //     : (arr as string | undefined);
-
-  //   // デバッグログを追加
-  //   console.log("first関数入力:", arr);
-  //   console.log("first関数出力:", result);
-  //   return result;
-  // };
 
   const nullIfEmpty = (s: string | null | undefined) =>
     s && s.trim() !== "" ? s : null;
@@ -139,10 +125,7 @@ export const ReportInputScreen = (): JSX.Element => {
     return `${dateStr}T${timeStr}${tzOffset}`;
   };
 
-  // ---------- convert for posting ----------
   const toJdbRecord = (v: ReportPostData): ReportPostData => {
-    // console.log("toJdbRecord入力:", v);
-
     const result = {
       field_workerId: toJdbRef(pickId(v.field_workerId)),
       field_carId: toJdbRef(pickId(v.field_carId)),
@@ -169,7 +152,6 @@ export const ReportInputScreen = (): JSX.Element => {
           : null,
     };
 
-    // console.log("toJdbRecord出力:", result);
     return result;
   };
 
@@ -189,6 +171,7 @@ export const ReportInputScreen = (): JSX.Element => {
   }, [errors]);
 
   const onValid = () => setShowConfirmation(true);
+
   const onInvalid = () => {
     setShowConfirmation(false);
     console.log("Invalid!");
@@ -198,28 +181,27 @@ export const ReportInputScreen = (): JSX.Element => {
     setIsSubmitting(true);
     try {
       const record = toJdbRecord(values);
-
-      // デバッグログを追加
-      // console.log("送信前のvalues:", values);
-      // console.log("変換後のrecord:", record);
-      // console.log("field_workerId変換前:", values.field_workerId);
-      // console.log("field_workerId変換後:", record.field_workerId);
-      // console.log("field_carId変換前:", values.field_carId);
-      // console.log("field_carId変換後:", record.field_carId);
-
       await postReport(record);
+
+      // タコメーター項目は現時点ではUI保持のみ
+      console.log("tachometerValue:", tachometerValue);
+      console.log(
+        "tachometerPhotos:",
+        tachometerPhotos.map((photo) => photo.file)
+      );
+
       setShowConfirmation(false);
-      // console.log("送信成功");
       reset();
+      setTachometerValue("");
+      setTachometerPhotos([]);
+      setSelectedLocationId(null);
+      setSelectedClassId(null);
     } catch (error) {
       console.error("送信エラー:", error);
     } finally {
       setIsSubmitting(false);
-      // console.log("送信完了");
     }
   };
-
-
 
   return (
     <>
@@ -239,6 +221,7 @@ export const ReportInputScreen = (): JSX.Element => {
 
       <div className="flex flex-col w-full items-center pt-4 pb-8 px-4 sm:px-6 bg-gradient-to-b from-sky-50 to-sky-100">
         <UserName />
+
         <div className="w-full max-w-4xl space-y-6">
           <NotificationSection
             title="日報入力"
@@ -249,18 +232,23 @@ export const ReportInputScreen = (): JSX.Element => {
             onLocationSelect={(loc) => {
               setSelectedLocationId(loc.id);
               setSelectedClassId(loc.typeId);
+
               setValue("field_workPlaceId", [String(loc.id)], {
                 shouldDirty: true,
               });
               setValue("field_workPlaceName", loc.name, { shouldDirty: true });
               clearErrors("field_workPlaceId");
+
               setValue("field_workClassId", loc.typeId, { shouldDirty: true });
               clearErrors("field_workClassId");
+
               setValue("field_workClassName", loc.typeName, {
                 shouldDirty: true,
               });
+
               setValue("field_carId", loc.carId, { shouldDirty: true });
               clearErrors("field_carId");
+
               setValue("field_carName", loc.carName, { shouldDirty: true });
             }}
           />
@@ -288,12 +276,14 @@ export const ReportInputScreen = (): JSX.Element => {
               setValue={setValue}
               values={values}
             />
+
             <WorkerVehicleSection
               register={register}
               errors={errors}
               setValue={setValue}
               values={values}
             />
+
             <WorkPlaceSection
               register={register}
               errors={errors}
@@ -304,18 +294,27 @@ export const ReportInputScreen = (): JSX.Element => {
                 setSelectedLocationId(loc.id);
                 clearErrors("field_workPlaceId");
               }}
-              onClassTypeSelect={(t)=>{
+              onClassTypeSelect={(t) => {
                 setSelectedClassId(t.id);
                 clearErrors("field_workClassId");
               }}
               selectedClassId={selectedClassId}
             />
+
             <WorkDurationSection
               register={register}
               errors={errors}
               setValue={setValue}
               values={values}
             />
+
+            <TachometerSection
+              tachometerValue={tachometerValue}
+              onTachometerChange={setTachometerValue}
+              photos={tachometerPhotos}
+              onPhotosChange={setTachometerPhotos}
+            />
+
             <WorkRecordSection
               register={register}
               errors={errors}

--- a/src/screens/ReportInputScreen/sections/TachometerSection.tsx
+++ b/src/screens/ReportInputScreen/sections/TachometerSection.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { CameraIcon, GaugeIcon, Trash2Icon } from "lucide-react";
+import { CameraIcon, GaugeIcon, Trash2Icon, PlusIcon } from "lucide-react";
 import { Input } from "../../../components/ui/input";
 import { Label } from "../../../components/ui/label";
 import { Button } from "../../../components/ui/button";
@@ -16,6 +16,8 @@ interface Props {
   onTachometerChange: (value: string) => void;
   photos: TachometerPhoto[];
   onPhotosChange: (photos: TachometerPhoto[]) => void;
+  memos: string[];
+  onMemosChange: (memos: string[]) => void;
 }
 
 export const TachometerSection = ({
@@ -23,6 +25,8 @@ export const TachometerSection = ({
   onTachometerChange,
   photos,
   onPhotosChange,
+  memos,
+  onMemosChange,
 }: Props): JSX.Element => {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -41,8 +45,6 @@ export const TachometerSection = ({
     }));
 
     onPhotosChange([...photos, ...newPhotos]);
-
-    // 同じファイルを再度選択できるようにリセット
     event.target.value = "";
   };
 
@@ -51,10 +53,24 @@ export const TachometerSection = ({
     if (target) {
       URL.revokeObjectURL(target.previewUrl);
     }
-
     onPhotosChange(photos.filter((photo) => photo.id !== photoId));
   };
 
+  const handleAddMemo = () => {
+    onMemosChange([...memos, ""]);
+  };
+
+  const handleMemoChange = (index: number, value: string) => {
+    const updated = [...memos];
+    updated[index] = value;
+    onMemosChange(updated);
+  };
+
+  const handleRemoveMemo = (index: number) => {
+    onMemosChange(memos.filter((_, i) => i !== index));
+  };
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     return () => {
       photos.forEach((photo) => URL.revokeObjectURL(photo.previewUrl));
@@ -66,11 +82,13 @@ export const TachometerSection = ({
       <CardContent className="p-5 space-y-5">
         <div className="flex items-center gap-2 mb-1">
           <GaugeIcon className="w-5 h-5 text-blue-500" />
-          <h2 className="text-lg font-semibold text-gray-500">タコメーター</h2>
+          <h2 className="text-sm font-semibold text-gray-700">タコメーター</h2>
         </div>
 
-        <div className="space-y-2">
-          <Label className="text-lg">走行距離 / メーター値</Label>
+        <div className="space-y-1.5">
+          <Label className="text-sm font-medium text-slate-600">
+            走行距離 / メーター値
+          </Label>
           <Input
             type="number"
             inputMode="numeric"
@@ -78,12 +96,16 @@ export const TachometerSection = ({
             placeholder="例: 125430"
             value={tachometerValue}
             onChange={(e) => onTachometerChange(e.target.value)}
-            className="h-11"
+            className="h-10 text-sm border-slate-200 focus:border-blue-300 focus:ring-blue-100"
           />
         </div>
 
+        <div className="border-t border-slate-100" />
+
         <div className="space-y-3">
-          <Label className="text-lg">タコメーター写真</Label>
+          <Label className="text-sm font-medium text-slate-600">
+            タコメーター写真
+          </Label>
 
           <input
             ref={fileInputRef}
@@ -98,14 +120,14 @@ export const TachometerSection = ({
           <Button
             type="button"
             onClick={handleOpenCamera}
-            className="w-full h-11 bg-blue-600 hover:bg-blue-700 text-white rounded-[10px]"
+            className="w-full h-10 bg-blue-50 hover:bg-blue-100 text-blue-600 border border-blue-200 hover:border-blue-300 rounded-lg text-sm font-medium shadow-none"
           >
             <CameraIcon className="w-4 h-4 mr-2" />
             カメラを起動
           </Button>
 
-          <p className="text-sm text-slate-500">
-            スマートフォンではカメラが起動し、撮影した写真が下にプレビュー表示されます。
+          <p className="text-xs text-slate-400">
+            スマートフォンではカメラが起動し、撮影した写真がプレビュー表示されます。
           </p>
 
           {photos.length > 0 && (
@@ -113,32 +135,75 @@ export const TachometerSection = ({
               {photos.map((photo) => (
                 <div
                   key={photo.id}
-                  className="relative overflow-hidden rounded-xl border border-slate-200 bg-slate-50"
+                  className="relative overflow-hidden rounded-lg border border-slate-200 bg-slate-50"
                 >
                   <img
                     src={photo.previewUrl}
                     alt="タコメーター写真プレビュー"
-                    className="w-full h-36 object-cover"
+                    className="w-full h-32 object-cover"
                   />
-
-                  <div className="p-2">
-                    <p className="text-xs text-slate-600 truncate">
+                  <div className="px-2 py-1.5">
+                    <p className="text-xs text-slate-500 truncate">
                       {photo.file.name}
                     </p>
                   </div>
-
                   <button
                     type="button"
                     onClick={() => handleRemovePhoto(photo.id)}
-                    className="absolute top-2 right-2 inline-flex items-center justify-center rounded-full bg-white/90 p-2 shadow hover:bg-white"
+                    className="absolute top-1.5 right-1.5 inline-flex items-center justify-center w-7 h-7 rounded-full bg-white/90 hover:bg-white border border-slate-200 transition-colors"
                     aria-label="写真を削除"
                   >
-                    <Trash2Icon className="w-4 h-4 text-red-500" />
+                    <Trash2Icon className="w-3.5 h-3.5 text-slate-400 hover:text-red-500" />
                   </button>
                 </div>
               ))}
             </div>
           )}
+        </div>
+
+        <div className="border-t border-slate-100" />
+        <div className="space-y-3">
+          <Label className="text-sm font-medium text-slate-600">メモ</Label>
+
+          {memos.length === 0 && (
+            <p className="text-xs text-slate-400">
+              メモはまだありません。ボタンを押して追加してください。
+            </p>
+          )}
+
+          <div className="space-y-2">
+            {memos.map((memo, index) => (
+              <div key={index} className="flex items-center gap-2">
+                <span className="text-xs text-slate-400 w-5 text-right shrink-0">
+                  {index + 1}
+                </span>
+                <Input
+                  type="text"
+                  placeholder={`メモを入力...`}
+                  value={memo}
+                  onChange={(e) => handleMemoChange(index, e.target.value)}
+                  className="h-10 flex-1 text-sm border-slate-200 focus:border-blue-300 focus:ring-blue-100"
+                />
+                <button
+                  type="button"
+                  onClick={() => handleRemoveMemo(index)}
+                  className="inline-flex items-center justify-center w-7 h-7 rounded-full hover:bg-red-50 transition-colors shrink-0"
+                  aria-label="メモを削除"
+                >
+                  <Trash2Icon className="w-3.5 h-3.5 text-slate-400 hover:text-red-500" />
+                </button>
+              </div>
+            ))}
+          </div>
+
+          <Button
+            type="button"
+            onClick={handleAddMemo}
+            className="w-full h-10 bg-blue-50 hover:bg-blue-100 text-blue-600 border border-blue-200 hover:border-blue-300 rounded-lg text-sm font-medium shadow-none"
+          >
+            <PlusIcon className="w-4 h-4 mr-2" />
+            メモを追加
+          </Button>
         </div>
       </CardContent>
     </Card>

--- a/src/screens/ReportInputScreen/sections/TachometerSection.tsx
+++ b/src/screens/ReportInputScreen/sections/TachometerSection.tsx
@@ -1,0 +1,146 @@
+import React, { useEffect, useRef } from "react";
+import { CameraIcon, GaugeIcon, Trash2Icon } from "lucide-react";
+import { Input } from "../../../components/ui/input";
+import { Label } from "../../../components/ui/label";
+import { Button } from "../../../components/ui/button";
+import { Card, CardContent } from "../../../components/ui/card";
+
+export interface TachometerPhoto {
+  id: string;
+  file: File;
+  previewUrl: string;
+}
+
+interface Props {
+  tachometerValue: string;
+  onTachometerChange: (value: string) => void;
+  photos: TachometerPhoto[];
+  onPhotosChange: (photos: TachometerPhoto[]) => void;
+}
+
+export const TachometerSection = ({
+  tachometerValue,
+  onTachometerChange,
+  photos,
+  onPhotosChange,
+}: Props): JSX.Element => {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleOpenCamera = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFiles = Array.from(event.target.files ?? []);
+    if (selectedFiles.length === 0) return;
+
+    const newPhotos: TachometerPhoto[] = selectedFiles.map((file) => ({
+      id: `${file.name}-${file.lastModified}-${Math.random().toString(36).slice(2)}`,
+      file,
+      previewUrl: URL.createObjectURL(file),
+    }));
+
+    onPhotosChange([...photos, ...newPhotos]);
+
+    // 同じファイルを再度選択できるようにリセット
+    event.target.value = "";
+  };
+
+  const handleRemovePhoto = (photoId: string) => {
+    const target = photos.find((photo) => photo.id === photoId);
+    if (target) {
+      URL.revokeObjectURL(target.previewUrl);
+    }
+
+    onPhotosChange(photos.filter((photo) => photo.id !== photoId));
+  };
+
+  useEffect(() => {
+    return () => {
+      photos.forEach((photo) => URL.revokeObjectURL(photo.previewUrl));
+    };
+  }, []);
+
+  return (
+    <Card className="w-full bg-white rounded-xl border border-slate-200 shadow-[0px_1px_3px_#0000001a]">
+      <CardContent className="p-5 space-y-5">
+        <div className="flex items-center gap-2 mb-1">
+          <GaugeIcon className="w-5 h-5 text-blue-500" />
+          <h2 className="text-lg font-semibold text-gray-500">タコメーター</h2>
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-lg">走行距離 / メーター値</Label>
+          <Input
+            type="number"
+            inputMode="numeric"
+            min="0"
+            placeholder="例: 125430"
+            value={tachometerValue}
+            onChange={(e) => onTachometerChange(e.target.value)}
+            className="h-11"
+          />
+        </div>
+
+        <div className="space-y-3">
+          <Label className="text-lg">タコメーター写真</Label>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            capture="environment"
+            multiple
+            className="hidden"
+            onChange={handleFileChange}
+          />
+
+          <Button
+            type="button"
+            onClick={handleOpenCamera}
+            className="w-full h-11 bg-blue-600 hover:bg-blue-700 text-white rounded-[10px]"
+          >
+            <CameraIcon className="w-4 h-4 mr-2" />
+            カメラを起動
+          </Button>
+
+          <p className="text-sm text-slate-500">
+            スマートフォンではカメラが起動し、撮影した写真が下にプレビュー表示されます。
+          </p>
+
+          {photos.length > 0 && (
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+              {photos.map((photo) => (
+                <div
+                  key={photo.id}
+                  className="relative overflow-hidden rounded-xl border border-slate-200 bg-slate-50"
+                >
+                  <img
+                    src={photo.previewUrl}
+                    alt="タコメーター写真プレビュー"
+                    className="w-full h-36 object-cover"
+                  />
+
+                  <div className="p-2">
+                    <p className="text-xs text-slate-600 truncate">
+                      {photo.file.name}
+                    </p>
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={() => handleRemovePhoto(photo.id)}
+                    className="absolute top-2 right-2 inline-flex items-center justify-center rounded-full bg-white/90 p-2 shadow hover:bg-white"
+                    aria-label="写真を削除"
+                  >
+                    <Trash2Icon className="w-4 h-4 text-red-500" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};


### PR DESCRIPTION

[Issue 52](https://github.com/youssefmetwalli/SnowRemoval/issues/52)



- 日報作成画面にタコメーター追加のセクションを追加

- そのセクションにスマートフォンのカメラを起動するボタンを追加

- 撮影した写真がプレビューとして表示されるようにしました


<img width="1258" height="436" alt="image" src="https://github.com/user-attachments/assets/fb458b5f-c71c-47e9-8e89-5e605bb40d17" />
