### PR TITLE
タコメーターのメモを登録する機能の実装

### DIFF
--- a/src/screens/ReportInputScreen/ReportInputScreen.tsx
+++ b/src/screens/ReportInputScreen/ReportInputScreen.tsx
@@ -22,10 +22,8 @@ export const ReportInputScreen = (): JSX.Element => {
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [tachometerValue, setTachometerValue] = useState("");
-  const [tachometerPhotos, setTachometerPhotos] = useState<TachometerPhoto[]>(
-    []
-  );
-
+  const [tachometerPhotos, setTachometerPhotos] = useState<TachometerPhoto[]>([],);
+  const [tachometerMemos, setTachometerMemos] = useState<string[]>([]);
   const { name, userId } = getCurrentUser();
 
   const isoToDate = (iso?: string) => {
@@ -68,8 +66,8 @@ export const ReportInputScreen = (): JSX.Element => {
     field_workDate: isoToDate(p?.field_workDate),
     field_workPlaceId: asArr(p?.field_workPlaceId),
     field_weather: Array.isArray(p?.field_weather)
-      ? p.field_weather[0] ?? ""
-      : p?.field_weather ?? "",
+      ? (p.field_weather[0] ?? "")
+      : (p?.field_weather ?? ""),
     field_workerName: p?.field_workerName ?? name,
     field_assistantId: asArr(p?.field_assistantId) ?? userId,
     field_assistantName: p?.field_assistantName ?? "",
@@ -81,7 +79,7 @@ export const ReportInputScreen = (): JSX.Element => {
     field_removalVolume:
       typeof p?.field_removalVolume === "number"
         ? String(p?.field_removalVolume)
-        : p?.field_removalVolume ?? "",
+        : (p?.field_removalVolume ?? ""),
   });
 
   const {
@@ -98,7 +96,7 @@ export const ReportInputScreen = (): JSX.Element => {
   });
 
   const [selectedLocationId, setSelectedLocationId] = useState<number | null>(
-    null
+    null,
   );
   const [selectedClassId, setSelectedClassId] = useState<string[] | null>(null);
 
@@ -182,18 +180,11 @@ export const ReportInputScreen = (): JSX.Element => {
     try {
       const record = toJdbRecord(values);
       await postReport(record);
-
-      // タコメーター項目は現時点ではUI保持のみ
-      console.log("tachometerValue:", tachometerValue);
-      console.log(
-        "tachometerPhotos:",
-        tachometerPhotos.map((photo) => photo.file)
-      );
-
       setShowConfirmation(false);
       reset();
       setTachometerValue("");
       setTachometerPhotos([]);
+      setTachometerMemos([]);
       setSelectedLocationId(null);
       setSelectedClassId(null);
     } catch (error) {
@@ -313,8 +304,9 @@ export const ReportInputScreen = (): JSX.Element => {
               onTachometerChange={setTachometerValue}
               photos={tachometerPhotos}
               onPhotosChange={setTachometerPhotos}
+              memos={tachometerMemos}
+              onMemosChange={setTachometerMemos}
             />
-
             <WorkRecordSection
               register={register}
               errors={errors}

--- a/src/screens/ReportInputScreen/sections/TachometerSection.tsx
+++ b/src/screens/ReportInputScreen/sections/TachometerSection.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { CameraIcon, GaugeIcon, Trash2Icon } from "lucide-react";
+import { CameraIcon, GaugeIcon, Trash2Icon, PlusIcon } from "lucide-react";
 import { Input } from "../../../components/ui/input";
 import { Label } from "../../../components/ui/label";
 import { Button } from "../../../components/ui/button";
@@ -16,6 +16,8 @@ interface Props {
   onTachometerChange: (value: string) => void;
   photos: TachometerPhoto[];
   onPhotosChange: (photos: TachometerPhoto[]) => void;
+  memos: string[];
+  onMemosChange: (memos: string[]) => void;
 }
 
 export const TachometerSection = ({
@@ -23,6 +25,8 @@ export const TachometerSection = ({
   onTachometerChange,
   photos,
   onPhotosChange,
+  memos,
+  onMemosChange,
 }: Props): JSX.Element => {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -41,8 +45,6 @@ export const TachometerSection = ({
     }));
 
     onPhotosChange([...photos, ...newPhotos]);
-
-    // 同じファイルを再度選択できるようにリセット
     event.target.value = "";
   };
 
@@ -51,10 +53,24 @@ export const TachometerSection = ({
     if (target) {
       URL.revokeObjectURL(target.previewUrl);
     }
-
     onPhotosChange(photos.filter((photo) => photo.id !== photoId));
   };
 
+  const handleAddMemo = () => {
+    onMemosChange([...memos, ""]);
+  };
+
+  const handleMemoChange = (index: number, value: string) => {
+    const updated = [...memos];
+    updated[index] = value;
+    onMemosChange(updated);
+  };
+
+  const handleRemoveMemo = (index: number) => {
+    onMemosChange(memos.filter((_, i) => i !== index));
+  };
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     return () => {
       photos.forEach((photo) => URL.revokeObjectURL(photo.previewUrl));
@@ -66,11 +82,13 @@ export const TachometerSection = ({
       <CardContent className="p-5 space-y-5">
         <div className="flex items-center gap-2 mb-1">
           <GaugeIcon className="w-5 h-5 text-blue-500" />
-          <h2 className="text-lg font-semibold text-gray-500">タコメーター</h2>
+          <h2 className="text-sm font-semibold text-gray-700">タコメーター</h2>
         </div>
 
-        <div className="space-y-2">
-          <Label className="text-lg">走行距離 / メーター値</Label>
+        <div className="space-y-1.5">
+          <Label className="text-sm font-medium text-slate-600">
+            走行距離 / メーター値
+          </Label>
           <Input
             type="number"
             inputMode="numeric"
@@ -78,12 +96,16 @@ export const TachometerSection = ({
             placeholder="例: 125430"
             value={tachometerValue}
             onChange={(e) => onTachometerChange(e.target.value)}
-            className="h-11"
+            className="h-10 text-sm border-slate-200 focus:border-blue-300 focus:ring-blue-100"
           />
         </div>
 
+        <div className="border-t border-slate-100" />
+
         <div className="space-y-3">
-          <Label className="text-lg">タコメーター写真</Label>
+          <Label className="text-sm font-medium text-slate-600">
+            タコメーター写真
+          </Label>
 
           <input
             ref={fileInputRef}
@@ -98,14 +120,14 @@ export const TachometerSection = ({
           <Button
             type="button"
             onClick={handleOpenCamera}
-            className="w-full h-11 bg-blue-600 hover:bg-blue-700 text-white rounded-[10px]"
+            className="w-full h-10 bg-blue-50 hover:bg-blue-100 text-blue-600 border border-blue-200 hover:border-blue-300 rounded-lg text-sm font-medium shadow-none"
           >
             <CameraIcon className="w-4 h-4 mr-2" />
             カメラを起動
           </Button>
 
-          <p className="text-sm text-slate-500">
-            スマートフォンではカメラが起動し、撮影した写真が下にプレビュー表示されます。
+          <p className="text-xs text-slate-400">
+            スマートフォンではカメラが起動し、撮影した写真がプレビュー表示されます。
           </p>
 
           {photos.length > 0 && (
@@ -113,32 +135,75 @@ export const TachometerSection = ({
               {photos.map((photo) => (
                 <div
                   key={photo.id}
-                  className="relative overflow-hidden rounded-xl border border-slate-200 bg-slate-50"
+                  className="relative overflow-hidden rounded-lg border border-slate-200 bg-slate-50"
                 >
                   <img
                     src={photo.previewUrl}
                     alt="タコメーター写真プレビュー"
-                    className="w-full h-36 object-cover"
+                    className="w-full h-32 object-cover"
                   />
-
-                  <div className="p-2">
-                    <p className="text-xs text-slate-600 truncate">
+                  <div className="px-2 py-1.5">
+                    <p className="text-xs text-slate-500 truncate">
                       {photo.file.name}
                     </p>
                   </div>
-
                   <button
                     type="button"
                     onClick={() => handleRemovePhoto(photo.id)}
-                    className="absolute top-2 right-2 inline-flex items-center justify-center rounded-full bg-white/90 p-2 shadow hover:bg-white"
+                    className="absolute top-1.5 right-1.5 inline-flex items-center justify-center w-7 h-7 rounded-full bg-white/90 hover:bg-white border border-slate-200 transition-colors"
                     aria-label="写真を削除"
                   >
-                    <Trash2Icon className="w-4 h-4 text-red-500" />
+                    <Trash2Icon className="w-3.5 h-3.5 text-slate-400 hover:text-red-500" />
                   </button>
                 </div>
               ))}
             </div>
           )}
+        </div>
+
+        <div className="border-t border-slate-100" />
+        <div className="space-y-3">
+          <Label className="text-sm font-medium text-slate-600">メモ</Label>
+
+          {memos.length === 0 && (
+            <p className="text-xs text-slate-400">
+              メモはまだありません。ボタンを押して追加してください。
+            </p>
+          )}
+
+          <div className="space-y-2">
+            {memos.map((memo, index) => (
+              <div key={index} className="flex items-center gap-2">
+                <span className="text-xs text-slate-400 w-5 text-right shrink-0">
+                  {index + 1}
+                </span>
+                <Input
+                  type="text"
+                  placeholder={`メモを入力...`}
+                  value={memo}
+                  onChange={(e) => handleMemoChange(index, e.target.value)}
+                  className="h-10 flex-1 text-sm border-slate-200 focus:border-blue-300 focus:ring-blue-100"
+                />
+                <button
+                  type="button"
+                  onClick={() => handleRemoveMemo(index)}
+                  className="inline-flex items-center justify-center w-7 h-7 rounded-full hover:bg-red-50 transition-colors shrink-0"
+                  aria-label="メモを削除"
+                >
+                  <Trash2Icon className="w-3.5 h-3.5 text-slate-400 hover:text-red-500" />
+                </button>
+              </div>
+            ))}
+          </div>
+
+          <Button
+            type="button"
+            onClick={handleAddMemo}
+            className="w-full h-10 bg-blue-50 hover:bg-blue-100 text-blue-600 border border-blue-200 hover:border-blue-300 rounded-lg text-sm font-medium shadow-none"
+          >
+            <PlusIcon className="w-4 h-4 mr-2" />
+            メモを追加
+          </Button>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
[Issue 53](https://github.com/youssefmetwalli/SnowRemoval/issues/53)
修正したファイル : src/screens/ReportInputScreen/ReportInputScreen.tsx とsrc/screens/ReportInputScreen/sections/TachometerSection.tsx

### TachometerSection.tsx

- メモ入力欄のUI（入力フィールド・削除ボタン・追加ボタン）を追加
- memos: string[] と onMemosChange の props を追加
- handleAddMemo・handleMemoChange・handleRemoveMemo のハンドラーを実装
- 見た目とスタイルを修正


### ReportInputScreen.tsx

- tachometerMemos の state を追加（useState<string[]>([])）
- フォーム送信後のリセット処理に setTachometerMemos([]) を追加
- TachometerSection に memos と onMemosChange の props を渡すように更新


<img width="1219" height="614" alt="image" src="https://github.com/user-attachments/assets/81395d9d-ffdf-4b04-9157-c2f38620d367" />


### 備考

- メモのDB保存処理は未実装（保存先が未定のため）
- [Pull 55- タコメーター撮影処理の実装](https://github.com/youssefmetwalli/SnowRemoval/pull/55)と編集したファイルが同じため、feature/tachometer-screenをこのPRのマージ先にしました